### PR TITLE
Shuffle printing to main.go and run go fmt, vet, and lint

### DIFF
--- a/cmd/gotls/main.go
+++ b/cmd/gotls/main.go
@@ -1,3 +1,5 @@
+//+build !test
+
 package main
 
 import (
@@ -104,6 +106,7 @@ func main() {
 					}
 					fmt.Println(string(b))
 				} else {
+					tlschk.Warning.Printf("WARNING: -noverify option specified. Only examining certificates sent by the remote server.\n")
 					for _, cert := range keyContainer.PublicKeys.PeerCertificates {
 						tlschk.PrintText(*cert)
 					}

--- a/print.go
+++ b/print.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-
-	"github.com/fatih/color"
 )
 
 const lightVerticalBar = "\u2758" // vertical bar
@@ -14,13 +12,10 @@ const arrowDownRight = "\u2937"   // down right arrow
 const emojiKey = "\U0001f511"     // key
 const emojiLock = "\U0001f512"    // lock
 
-var label = color.New(color.FgRed, color.Bold).SprintFunc()
-var warning = color.New(color.FgRed, color.Bold, color.Underline)
-
 func printField(prefix string, field string, value interface{}) {
 	// Nasty hard-coded paddings. These should be calculated based on the
 	// width of the longest field name.
-	fmt.Printf("%-5s%-24s\t%s\n", prefix, label(field), value)
+	fmt.Printf("%-5s%-24s\t%s\n", prefix, Label(field), value)
 }
 
 func printDefaultField(field string, value interface{}) {

--- a/print_test.go
+++ b/print_test.go
@@ -3,7 +3,6 @@ package tlschk
 import (
 	//"crypto/x509"
 
-
 	//"github.com/fatih/color"
 	//"fmt"
 	"testing"
@@ -18,7 +17,7 @@ func TestPrintText(t *testing.T) {
 	k, err = ProcessCerts(k, certFile)
 	if err != nil {
 		t.Errorf(err.Error())
-	}	
+	}
 	c := k.PublicKeys.LocalCertificates[0]
 	PrintText(*c)
 }

--- a/process_test.go
+++ b/process_test.go
@@ -31,7 +31,7 @@ func TestParseCert(t *testing.T) {
 }
 
 func TestDecodeKey(t *testing.T) {
-	var k KeyContainer	
+	var k KeyContainer
 	k.PrivateKey.Bytes, _ = readFile(keyFile)
 	_, err := k.decodeKey()
 	if err != nil {
@@ -93,4 +93,3 @@ func TestProcessCerts(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 }
-

--- a/remote.go
+++ b/remote.go
@@ -23,7 +23,6 @@ func CheckCerts(conn *tls.Conn, k KeyContainer) (KeyContainer, error) {
 		}
 		k.PublicKeys.VerifiedChains = conn.ConnectionState().VerifiedChains[0]
 	} else { // use unverified cert chain, e.g. when connecting with -insecure
-		warning.Printf("WARNING: -noverify option specified. Only examining certificates sent by the remote server.\n")
 		k.PublicKeys.PeerCertificates = conn.ConnectionState().PeerCertificates
 	}
 	return k, nil

--- a/vars.go
+++ b/vars.go
@@ -1,0 +1,12 @@
+package tlschk
+
+import (
+	"github.com/fatih/color"
+)
+
+var (
+	//Label prints with nice formatting
+	Label = color.New(color.FgRed, color.Bold).SprintFunc()
+	//Warning tries to really stand out with extra underline
+	Warning = color.New(color.FgRed, color.Bold, color.Underline)
+)


### PR DESCRIPTION
Tidying for reuse as a separate tool, which requires moving printing warnings out of the package and into main. This way the package just exposes its public methods and leaves manipulating the output to the tool including gotls.
